### PR TITLE
Used maven:3.5.0-jdk-8 instead maven:3.5.0-jdk-8-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.5.0-jdk-8-alpine
+FROM maven:3.5.0-jdk-8
 EXPOSE 8080
 
 WORKDIR /tmp/src/


### PR DESCRIPTION
Fixed problem with using JVM tools inside Docker container